### PR TITLE
feat: Improve network requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # 끼룩끼룩 Web Frontend 리팩토링 대작전
 
 끼룩끼룩 프로젝트의 프론트엔드 성능 개선을 위한 프로젝트입니다.
-[원본 레포지토리 링크](https://github.com/taco-official/klkl-client.git)
+[[원본 레포지토리]](https://github.com/taco-official/klkl-client.git)
 
 네트워크 요청 처리 속도를 중점으로 개선합니다.
 
-## 목차
+## 📋 목차
 
-1. 네트워크 요청 개선
+1. **네트워크 요청 개선**
 
 ## ✨ 네트워크 요청 개선
 
@@ -15,6 +15,12 @@
 
 - 서로 영향을 주지 않는 독립적인 요청 작업에 대해 Promise.all() 메소드의 사용으로 병렬 처리하였습니다.
 - reject 발생 시 페이지 이용에 문제가 있으므로 Error Page로 redirect됩니다.
+
+**병렬 처리 적용 loader 목록**
+
+  - feedLoader
+  - homeLoader
+  - productEditLoader
 
 ### ✅ Before
 
@@ -30,4 +36,4 @@
 
 ### 이메일
 
-seoulyego youngsk786@gmail.com
+seoulyego yeongo@student.42seoul.kr

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
-# 끼룩끼룩 Web Client 리팩토링 대작전
+# 끼룩끼룩 Web Frontend 리팩토링 대작전
+
+끼룩끼룩 프로젝트의 프론트엔드 성능 개선을 위한 프로젝트입니다.
+[원본 레포지토리 링크](https://github.com/taco-official/klkl-client.git)
+
+네트워크 요청 처리 속도를 중점으로 개선합니다.
+
+## 목차
+
+1. 네트워크 요청 개선
 
 ## ✨ 네트워크 요청 개선
 
+다중 네트워크 요청이 발생하는 loader 함수의 요청을 병렬 처리하여 로딩 시간을 약 40% 단축하였습니다.
+
+- 서로 영향을 주지 않는 독립적인 요청 작업에 대해 Promise.all() 메소드의 사용으로 병렬 처리하였습니다.
+- reject 발생 시 페이지 이용에 문제가 있으므로 Error Page로 redirect됩니다.
+
 ### ✅ Before
 
-![before](https://github.com/user-attachments/assets/fead2c5b-30f0-41f2-b510-9b588f30146d)
+<img src="https://github.com/user-attachments/assets/fead2c5b-30f0-41f2-b510-9b588f30146d">
 
 ### ✅ After
 
-![after](https://github.com/user-attachments/assets/dca473e3-91d0-4c9c-8c99-30d3e6267381)
+<img src="https://github.com/user-attachments/assets/dca473e3-91d0-4c9c-8c99-30d3e6267381">
+
+---
+
+## 문의
+
+### 이메일
+
+seoulyego youngsk786@gmail.com

--- a/src/loader/feedLoader.js
+++ b/src/loader/feedLoader.js
@@ -1,12 +1,22 @@
 import kyInstance from '@utils/kyInstance'
 
 const feedLoader = async () => {
-  try {
-    const regionData = await kyInstance.get('regions/hierarchy').json()
-    const categoryData = await kyInstance.get('categories/hierarchy').json()
-    return { regionData, categoryData }
-  } catch (error) {
+  const regionRequest = kyInstance.get('regions/hierarchy').json()
+  const categoryRequest = kyInstance.get('categories/hierarchy').json()
+
+  const responseData = await Promise.all([
+    regionRequest,
+    categoryRequest,
+  ]).catch((error) => {
     throw Error(`${error.response.status}`)
+  })
+
+  console.log(`regionData: ${responseData[0]}`)
+  console.log(`categoryData: ${responseData[1]}`)
+
+  return {
+    regionData: responseData[0],
+    categoryData: responseData[1],
   }
 }
 

--- a/src/loader/homeLoader.js
+++ b/src/loader/homeLoader.js
@@ -1,18 +1,26 @@
 import kyInstance from '@utils/kyInstance'
 
 const homeLoader = async () => {
-  try {
-    const newReviews = await kyInstance
-      .get('products?sort_by=created_at&size=12')
-      .json()
+  const newReviewsRequest = kyInstance
+    .get('products?sort_by=created_at&size=12')
+    .json()
+  const popularReviewsRequest = kyInstance
+    .get('products?sort_by=like_count&size=12')
+    .json()
 
-    const popularReviews = await kyInstance
-      .get('products?sort_by=like_count&size=12')
-      .json()
-
-    return { newReviews, popularReviews }
-  } catch (error) {
+  const responseData = await Promise.all([
+    newReviewsRequest,
+    popularReviewsRequest,
+  ]).catch((error) => {
     throw Error(`${error.response.status}`)
+  })
+
+  console.log(`newReviews: ${responseData[0]}`)
+  console.log(`popularReviews: ${responseData[1]}`)
+
+  return {
+    newReviews: responseData[0],
+    popularReviews: responseData[1],
   }
 }
 

--- a/src/loader/productEditLoader.js
+++ b/src/loader/productEditLoader.js
@@ -1,19 +1,23 @@
 import kyInstance from '@utils/kyInstance'
 
-const productLoader = async ({ params }) => {
+const productEditLoader = async ({ params }) => {
   const { id } = params
 
-  try {
-    const clientData = await kyInstance.get('me').json()
-    const productData = await kyInstance.get(`products/${id}`).json()
+  const clientRequest = kyInstance.get('me').json()
+  const productRequest = kyInstance.get(`products/${id}`).json()
 
-    if (clientData.data.id !== productData.data.member.id)
-      throw new Response('Forbidden', { status: 403 })
+  const responseData = await Promise.all([clientRequest, productRequest]).catch(
+    (error) => {
+      throw Error(`${error.response.status}`)
+    }
+  )
+  const clientData = responseData[0]
+  const productData = responseData[1]
 
-    return productData
-  } catch (error) {
-    throw Error(`${error.response.status}`)
-  }
+  if (clientData.data.id !== productData.data.member.id)
+    throw new Response('Forbidden', { status: 403 })
+
+  return productData
 }
 
-export default productLoader
+export default productEditLoader

--- a/src/loader/productLoader.js
+++ b/src/loader/productLoader.js
@@ -3,12 +3,13 @@ import kyInstance from '@utils/kyInstance'
 const productLoader = async ({ params }) => {
   const { id } = params
 
-  try {
-    const response = await kyInstance.get(`products/${id}`).json()
-    return response
-  } catch (error) {
-    throw Error(`${error.response.status}`)
+  const response = await kyInstance.get(`products/${id}`).json()
+
+  if (!response.ok) {
+    throw new Error(`${response.status}`)
   }
+
+  return response
 }
 
 export default productLoader

--- a/src/loader/userLoader.js
+++ b/src/loader/userLoader.js
@@ -3,12 +3,13 @@ import kyInstance from '@utils/kyInstance'
 const userLoader = async ({ params }) => {
   const { id } = params
 
-  try {
-    const response = await kyInstance.get(`members/${id}`).json()
-    return response
-  } catch (error) {
-    throw Error(`${error.response.status}`)
+  const response = await kyInstance.get(`members/${id}`).json()
+
+  if (!response.ok) {
+    throw new Error(`${response.status}`)
   }
+
+  return response
 }
 
 export default userLoader


### PR DESCRIPTION
## 📝 작업 내용
다중 네트워크 요청이 발생하는 loader 함수의 요청을 병렬 처리하여 로딩 시간을 약 40% 단축하였습니다.

- 서로 영향을 주지 않는 독립적인 요청 작업에 대해 Promise.all() 메소드의 사용으로 병렬 처리하였습니다.
- reject 발생 시 페이지 이용에 문제가 있으므로 Error Page로 redirect됩니다.

작업 내용을 바탕으로 README.md를 작성하였습니다.

## 🌳 작업 브랜치명
ImproveNetworkRequests

## 📸 스크린샷
### ✅ Before

<img src="https://github.com/user-attachments/assets/fead2c5b-30f0-41f2-b510-9b588f30146d">

### ✅ After

<img src="https://github.com/user-attachments/assets/dca473e3-91d0-4c9c-8c99-30d3e6267381">

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요